### PR TITLE
TS typings key & def fix

### DIFF
--- a/email.d.ts
+++ b/email.d.ts
@@ -1,6 +1,4 @@
-declare module "nativescript-email" {
-
-    interface Attachment {
+    export interface Attachment {
       /**
        * The name used for the attachment.
        * Example:
@@ -81,4 +79,3 @@ declare module "nativescript-email" {
      * On Android it's always true, unfortunately.
      */
     export function compose(options: ComposeOptions): Promise<boolean>;
-}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.2",
   "description": "Email plugin for your NativeScript app",
   "main": "email.js",
+  "typings": email.d.ts",
   "nativescript": {
     "platforms": {
       "ios": "2.3.0",
@@ -24,6 +25,13 @@
     "Attachment"
   ],
   "author": "Eddy Verbruggen <eddyverbruggen@gmail.com> (https://github.com/EddyVerbruggen)",
+  "contributors": [
+    {
+      "name": "Brad Martin",
+      "email": "bradwaynemartin@gmail.com",
+      "url": "https://github.com/BradMartin"
+    }
+  ],
   "license": "MIT",
   "bugs": "https://github.com/eddyverbruggen/nativescript-email/issues",
   "homepage": "https://github.com/eddyverbruggen/nativescript-email"


### PR DESCRIPTION
Removing the module declaration should resolve some TS warnings with certain IDEs.
- Added `export` to Attachment
- Added the `typings` key to the package.json to also help resolve the package.
